### PR TITLE
alternative simple notifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.597</version><!-- which version of Jenkins is this plugin built against? Users must have at least this Jenkins version to use this plugin. -->
+    <version>1.609</version><!-- which version of Jenkins is this plugin built against? Users must have at least this Jenkins version to use this plugin. -->
   </parent>
 
   <artifactId>phabricator-plugin</artifactId>

--- a/src/main/java/com/uber/jenkins/phabricator/HarbormasterConduitNotifier.java
+++ b/src/main/java/com/uber/jenkins/phabricator/HarbormasterConduitNotifier.java
@@ -1,0 +1,114 @@
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.jenkins.phabricator;
+
+import com.uber.jenkins.phabricator.utils.Logger;
+import hudson.EnvVars;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.Result;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Notifier;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicNameValuePair;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class HarbormasterConduitNotifier extends Notifier {
+    private static final String TAG = "harbormaster-conduit";
+
+    private final String buildTarget;
+
+    @DataBoundConstructor
+    public HarbormasterConduitNotifier(String buildTarget) {
+        this.buildTarget = buildTarget;
+    }
+
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.NONE;
+    }
+
+    @Override
+    public final boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher,
+                                 final BuildListener listener) throws InterruptedException, IOException {
+        String harbormasterResult = "fail";
+        EnvVars environment = build.getEnvironment(listener);
+        Logger log = new Logger(listener.getLogger());
+        Result buildResult = build.getResult();
+
+        // TODO(cburroughs): make this more sophisticated, or configurable
+        if (buildResult.isBetterOrEqualTo(hudson.model.Result.UNSTABLE)) {
+            harbormasterResult = "pass";
+        }
+        log.info(TAG, "Translated harbormaster build result: " + harbormasterResult);
+        String buildTargetPHID = environment.get(buildTarget);
+        if (buildTargetPHID == null) {
+            log.info(TAG, "Unable to find value for paramter: " + buildTarget);
+            return false;
+        }
+        harbormasterSendMessage(log, getDescriptor().getConduitURL(), getDescriptor().getConduitToken(), buildTargetPHID, harbormasterResult);
+        return true;
+    }
+
+    private void harbormasterSendMessage(Logger log, String conduitURL, String conduitToken, String buildTargetPHID, String harbormasterResult) {
+        try {
+            CloseableHttpClient client = HttpClientBuilder.create().build();
+            HttpPost httppost = new HttpPost(conduitURL + "/harbormaster.sendmessage");
+            List<NameValuePair> formparams = new ArrayList<NameValuePair>();
+            formparams.add(new BasicNameValuePair("api.token", conduitToken));
+            formparams.add(new BasicNameValuePair("buildTargetPHID", buildTargetPHID));
+            formparams.add(new BasicNameValuePair("type", harbormasterResult));
+            UrlEncodedFormEntity entity = new UrlEncodedFormEntity(formparams);
+            httppost.setEntity(entity);
+            HttpResponse response = client.execute(httppost);
+
+            if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+                log.info(TAG, "Call failed: " + response.getStatusLine());
+            }
+        } catch (HttpResponseException e) {
+            if (e.getStatusCode() != 404) {
+                e.printStackTrace(log.getStream());
+            }
+        } catch (ClientProtocolException e) {
+            e.printStackTrace(log.getStream());
+        } catch (IOException e) {
+            e.printStackTrace(log.getStream());
+        }
+    }
+
+    @Override
+    public HarbormasterConduitNotifierDescriptor getDescriptor() {
+        return (HarbormasterConduitNotifierDescriptor) super.getDescriptor();
+    }
+}

--- a/src/main/java/com/uber/jenkins/phabricator/HarbormasterConduitNotifierDescriptor.java
+++ b/src/main/java/com/uber/jenkins/phabricator/HarbormasterConduitNotifierDescriptor.java
@@ -1,0 +1,85 @@
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package com.uber.jenkins.phabricator;
+
+import hudson.Extension;
+import hudson.model.AbstractProject;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.Publisher;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.StaplerRequest;
+
+@Extension
+public class HarbormasterConduitNotifierDescriptor extends BuildStepDescriptor<Publisher> {
+    private String conduitURL;
+    private String conduitToken;
+    private boolean enabled = true;
+
+    public HarbormasterConduitNotifierDescriptor() {
+        super(HarbormasterConduitNotifier.class);
+        load();
+    }
+
+    public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+        return getEnabled();
+    }
+
+    public String getDisplayName() {
+        return "Callback to Harbormaster";
+    }
+
+    @Override
+    public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
+        if (formData.containsKey("harbormaster-conduit-notifier")) {
+            req.bindJSON(this, formData.getJSONObject("harbormaster-conduit-notifier"));
+            setEnabled(true);
+        } else {
+            setEnabled(false);
+        }
+        save();
+        return super.configure(req, formData);
+    }
+
+    public boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    public String getConduitURL() {
+        if (conduitURL != null && !"".equals(conduitURL)) {
+            return conduitURL;
+        }
+        return null;
+    }
+
+    public void setConduitURL(String value) {
+        conduitURL = value;
+    }
+
+    public String getConduitToken() {
+        return conduitToken;
+    }
+
+    public void setConduitToken(String conduitToken) {
+        this.conduitToken = conduitToken;
+    }
+}

--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapperDescriptor.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorBuildWrapperDescriptor.java
@@ -32,6 +32,7 @@ public final class PhabricatorBuildWrapperDescriptor extends BuildWrapperDescrip
     private String conduitURL;
     private String conduitToken;
     private String arcPath;
+    private boolean enabled = true;
 
     public PhabricatorBuildWrapperDescriptor() {
         super(PhabricatorBuildWrapper.class);
@@ -40,7 +41,7 @@ public final class PhabricatorBuildWrapperDescriptor extends BuildWrapperDescrip
 
     @Override
     public boolean isApplicable(AbstractProject<?, ?> abstractProject) {
-        return true;
+        return getEnabled();
     }
 
     /**
@@ -54,9 +55,22 @@ public final class PhabricatorBuildWrapperDescriptor extends BuildWrapperDescrip
     public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
         // To persist global configuration information,
         // set that to properties and call save().
-        req.bindJSON(this, formData.getJSONObject("phabricator"));
+        if (formData.containsKey("phabricator")) {
+            req.bindJSON(this, formData.getJSONObject("phabricator"));
+            setEnabled(true);
+        } else {
+            setEnabled(false);
+        }
         save();
         return super.configure(req,formData);
+    }
+
+    public boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
     }
 
     public String getConduitURL() {

--- a/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifierDescriptor.java
+++ b/src/main/java/com/uber/jenkins/phabricator/PhabricatorNotifierDescriptor.java
@@ -42,6 +42,7 @@ public final class PhabricatorNotifierDescriptor extends BuildStepDescriptor<Pub
     private String uberallsURL;
     private String commentFile;
     private String commentSize;
+    private boolean enabled = true;
 
     public PhabricatorNotifierDescriptor() {
         super(PhabricatorNotifier.class);
@@ -57,8 +58,7 @@ public final class PhabricatorNotifierDescriptor extends BuildStepDescriptor<Pub
     }
 
     public boolean isApplicable(Class<? extends AbstractProject> aClass) {
-        // Indicates that this builder can be used with all kinds of project types
-        return true;
+        return getEnabled();
     }
 
     /**
@@ -72,9 +72,22 @@ public final class PhabricatorNotifierDescriptor extends BuildStepDescriptor<Pub
     public boolean configure(StaplerRequest req, JSONObject formData) throws FormException {
         // To persist global configuration information,
         // set that to properties and call save().
-        req.bindJSON(this, formData.getJSONObject("uberalls"));
+        if (formData.containsKey("uberalls")) {
+            req.bindJSON(this, formData.getJSONObject("uberalls"));
+            setEnabled(true);
+        } else {
+            setEnabled(false);
+        }
         save();
         return super.configure(req, formData);
+    }
+
+    public boolean getEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
     }
 
     public String getConduitURL() {

--- a/src/main/resources/com/uber/jenkins/phabricator/HarbormasterConduitNotifier/config.jelly
+++ b/src/main/resources/com/uber/jenkins/phabricator/HarbormasterConduitNotifier/config.jelly
@@ -1,0 +1,6 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <f:entry title="Build Target" field="buildTarget"
+           description="Name of the env variable containering the Build Target PHID">
+     <f:textbox default="BUILD_TARGET" />
+  </f:entry>
+</j:jelly>

--- a/src/main/resources/com/uber/jenkins/phabricator/HarbormasterConduitNotifier/global.jelly
+++ b/src/main/resources/com/uber/jenkins/phabricator/HarbormasterConduitNotifier/global.jelly
@@ -1,0 +1,26 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+  <!--
+    This Jelly script is used to produce the global configuration option.
+
+    Jenkins uses a set of tag libraries to provide uniformity in forms.
+    To determine where this tag is defined, first check the namespace URI,
+    and then look under $JENKINS/views/. For example, <f:section> is defined
+    in $JENKINS/views/lib/form/section.jelly.
+
+    It's also often useful to just check other similar scripts to see what
+    tags they use. Views are always organized according to its owner class,
+    so it should be straightforward to find them.
+  -->
+  <f:section title="Phabricator">
+    <f:optionalBlock title="Harbormaster Conduit Publisher" name="harbormaster-conduit-notifier" checked="true">
+      <f:entry title="Conduit URL" field="conduitURL"
+               description="Location of the Phabricator API">
+        <f:textbox />
+      </f:entry>
+      <f:entry title="Conduit Token" field="conduitToken"
+               description="Conduit Token">
+        <f:textbox />
+      </f:entry>
+    </f:optionalBlock>
+  </f:section>
+</j:jelly>

--- a/src/main/resources/com/uber/jenkins/phabricator/PhabricatorBuildWrapper/global.jelly
+++ b/src/main/resources/com/uber/jenkins/phabricator/PhabricatorBuildWrapper/global.jelly
@@ -11,18 +11,20 @@
     tags they use. Views are always organized according to its owner class,
     so it should be straightforward to find them.
   -->
-  <f:section title="Phabricator" name="phabricator">
-    <f:entry title="Phabricator URL" field="conduitURL"
-      description="Location of the Phabricator instance">
-      <f:textbox />
-    </f:entry>
-    <f:entry title="Conduit Token" field="conduitToken"
-      description="Conduit token for Phabricator API. If left blank, reads from ~/.arcrc">
-      <f:textbox />
-    </f:entry>
-    <f:entry title="Location of arcanist" field="arcPath"
-      description="location of `arc` binary, if not in path">
-      <f:textbox default="arc" />
-    </f:entry>
+  <f:section title="Phabricator">
+    <f:optionalBlock title="Arc Patch Change Handoff" name="phabricator" checked="true">
+      <f:entry title="Phabricator URL" field="conduitURL"
+               description="Location of the Phabricator instance">
+        <f:textbox />
+      </f:entry>
+      <f:entry title="Conduit Token" field="conduitToken"
+               description="Conduit token for Phabricator API. If left blank, reads from ~/.arcrc">
+        <f:textbox />
+      </f:entry>
+      <f:entry title="Location of arcanist" field="arcPath"
+               description="location of `arc` binary, if not in path">
+        <f:textbox default="arc" />
+      </f:entry>
+    </f:optionalBlock>
   </f:section>
 </j:jelly>

--- a/src/main/resources/com/uber/jenkins/phabricator/PhabricatorNotifier/global.jelly
+++ b/src/main/resources/com/uber/jenkins/phabricator/PhabricatorNotifier/global.jelly
@@ -11,10 +11,12 @@
     tags they use. Views are always organized according to its owner class,
     so it should be straightforward to find them.
   -->
-  <f:section title="Uberalls" name="uberalls">
-    <f:entry title="Uberalls URL" field="uberallsURL"
-      description="Location of the Uberalls instance">
-      <f:textbox />
-    </f:entry>
-  </f:section>
+  <f:section title="Uberalls">
+    <f:optionalBlock title="Arc Callback with Uberalls" name="uberalls" checked="true">
+      <f:entry title="Uberalls URL" field="uberallsURL"
+               description="Location of the Uberalls instance">
+        <f:textbox />
+      </f:entry>
+    </f:optionalBlock>
+    </f:section>
 </j:jelly>


### PR DESCRIPTION
I wanted to take a fairly different approach to harbormaster integration.  Specifically:
- Don't rely on a local arc install
- Use staging repositories for handoff: https://secure.phabricator.com/book/phabricator/article/harbormaster/  This allows just checking out `refs/tags/${GIT_TAG}` using existing plugins & paramters.

Having _two_ "phabricator jenkins plugins" seems like an obviously bad state of affairs, so I wanted to show what I had so far and see if was trending towards a mergable direction.  I tried to not touch any of the existing stuff except to make it optional.  This creates some annoying global duplication in config, but I migration appeared very complicated (I don't have a whole lot of experience with jenkins plugin development).  Longer term (like after Phabricator does something with it) I think generic integration wtih code and line coverage would be an obviously good path to go down, and this plugin seems well poised to do that.

It that sounds reasonable let me know what needs to be cleaned up.  I'm also usualy in `#phabricator` if this is totally confusing and needs more context.

Known issues:
- This produces 2 `Phabricator` sections in the global config page.  I don't know what jelly magic is needed to fix that.
